### PR TITLE
VXI11 error handling fixes

### DIFF
--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -646,9 +646,11 @@ class GPIBSession(_GPIBCommon):
     @staticmethod
     def list_resources() -> List[str]:
         return [
-            "GPIB%d::%d::INSTR" % (board, pad)
-            if sad == 0
-            else "GPIB%d::%d::%d::INSTR" % (board, pad, sad - 0x60)
+            (
+                "GPIB%d::%d::INSTR" % (board, pad)
+                if sad == 0
+                else "GPIB%d::%d::%d::INSTR" % (board, pad, sad - 0x60)
+            )
             for board, pad, sad in _find_listeners()
         ]
 

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -226,7 +226,7 @@ class CoreClient(rpc.TCPClient):
                 self.unpacker.unpack_device_write_resp,
             )
         except socket.timeout as e:
-            return ErrorCodes.io_error, e.args[0]
+            return ErrorCodes.io_timeout, e.args[0]
 
     def device_read(
         self, link, request_size, io_timeout, lock_timeout, flags, term_char
@@ -240,7 +240,7 @@ class CoreClient(rpc.TCPClient):
                 self.unpacker.unpack_device_read_resp,
             )
         except socket.timeout as e:
-            return ErrorCodes.io_error, e.args[0], ""
+            return ErrorCodes.io_timeout, e.args[0], ""
 
     def device_read_stb(self, link, flags, lock_timeout, io_timeout):
         params = (link, flags, lock_timeout, io_timeout)

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -46,7 +46,7 @@ except ImportError:
 # DWR - Error 6 seems like a good match for channel_not_established, I changed
 # 29 to error_system_error from error_window_already_mapped. The only command
 # that returns 29 is create_intr_chan when the channel is already established.
-# Also, create_event isn't implemented in pyvisa-py at this point so we shouldn't 
+# Also, create_event isn't implemented in pyvisa-py at this point so we shouldn't
 # see that error or 6 anyway
 VXI11_ERRORS_TO_VISA = {
     0: StatusCode.success,  # no_error
@@ -260,9 +260,11 @@ class TCPIPInstrHiSLIP(Session):
             status = (
                 StatusCode.success_termination_character_read
                 if self.interface._rmt
-                else StatusCode.success_max_count_read
-                if len(data) >= count
-                else StatusCode.success
+                else (
+                    StatusCode.success_max_count_read
+                    if len(data) >= count
+                    else StatusCode.success
+                )
             )
 
         except socket.timeout:
@@ -1339,9 +1341,11 @@ class TCPIPSocketSession(Session):
         if self.interface:
             value = self.interface.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
             return (
-                constants.VisaBoolean.true
-                if value == 1
-                else constants.VisaBoolean.false,
+                (
+                    constants.VisaBoolean.true
+                    if value == 1
+                    else constants.VisaBoolean.false
+                ),
                 StatusCode.success,
             )
         return constants.VisaBoolean.false, StatusCode.error_nonsupported_attribute
@@ -1362,9 +1366,11 @@ class TCPIPSocketSession(Session):
         if self.interface:
             value = self.interface.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
             return (
-                constants.VisaBoolean.true
-                if value == 1
-                else constants.VisaBoolean.false,
+                (
+                    constants.VisaBoolean.true
+                    if value == 1
+                    else constants.VisaBoolean.false
+                ),
                 StatusCode.success,
             )
         return constants.VisaBoolean.false, StatusCode.error_nonsupported_attribute

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -43,6 +43,11 @@ except ImportError:
 
 # Conversion between VXI11 error codes and VISA status
 # TODO this is so far a best guess, in particular 6 and 29 are likely wrong
+# DWR - Error 6 seems like a good match for channel_not_established, I changed
+# 29 to error_system_error from error_window_already_mapped. The only command
+# that returns 29 is create_intr_chan when the channel is already established.
+# Also, create_event isn't implemented in pyvisa-py at this point so we shouldn't 
+# see that error or 6 anyway
 VXI11_ERRORS_TO_VISA = {
     0: StatusCode.success,  # no_error
     1: StatusCode.error_invalid_format,  # syntax_error
@@ -57,7 +62,7 @@ VXI11_ERRORS_TO_VISA = {
     15: StatusCode.error_timeout,  # io_timeout
     17: StatusCode.error_io,  # io_error
     23: StatusCode.error_abort,  # abort
-    29: StatusCode.error_window_already_mapped,  # channel_already_established
+    29: StatusCode.error_system_error,  # channel_already_established
 }
 
 
@@ -561,10 +566,12 @@ class TCPIPInstrVxi11(Session):
                 self.link, chunk_length, timeout, self.lock_timeout, flags, term_char
             )
 
+            # DWR - it would be nice if we could differentiate between a socket timeout
+            # and an intrument returned timeout.
             if error == vxi11.ErrorCodes.io_timeout:
                 return bytes(read_data), StatusCode.error_timeout
             elif error:
-                return bytes(read_data), StatusCode.error_io
+                return bytes(read_data), VXI11_ERRORS_TO_VISA[error]
 
             read_data.extend(data)
             count -= len(data)
@@ -613,8 +620,10 @@ class TCPIPInstrVxi11(Session):
                 if error == vxi11.ErrorCodes.io_timeout:
                     return offset, StatusCode.error_timeout
 
-                elif error or size < len(block):
+                elif size < len(block):
                     return offset, StatusCode.error_io
+                elif error:
+                    return offset, VXI11_ERRORS_TO_VISA[error]
 
                 offset += size
                 num -= size

--- a/pyvisa_py/testsuite/test_vxi11.py
+++ b/pyvisa_py/testsuite/test_vxi11.py
@@ -15,10 +15,11 @@ from ..sessions import Session, UnknownAttribute, VISARMSession
 # Test enhanced error returns from TCPIPInstrVxi11.read, write to
 # map VXI11 errors to VISA errors
 
+
 def setup_TCPIPinstrVxi11_mock():
     # Short circuit connection so this works w/o a real device
     TCPIPInstrVxi11.__init__ = MagicMock(return_value=None)
-    client = TCPIPInstrVxi11(VISARMSession, "TCPIP::169.254.12.34::5678",None, 2000)
+    client = TCPIPInstrVxi11(VISARMSession, "TCPIP::169.254.12.34::5678", None, 2000)
     client.interface = MagicMock()
     client.max_recv_size = 1024
     client.attrs = {}
@@ -27,30 +28,36 @@ def setup_TCPIPinstrVxi11_mock():
     client.lock_timeout = 5000
     return client
 
+
 def test_TCPIPinstrVxi11_read():
     client = setup_TCPIPinstrVxi11_mock()
     for map_error in VXI11_ERRORS_TO_VISA.keys():
-        client.interface.device_read = MagicMock(side_effect=lambda a,b,c,d,e,f: (map_error, vxi11.RX_END, b'data'))
+        client.interface.device_read = MagicMock(
+            side_effect=lambda a, b, c, d, e, f: (map_error, vxi11.RX_END, b"data")
+        )
         data, error = client.read(1024)
         assert error == VXI11_ERRORS_TO_VISA[map_error]
-        if (map_error == 0):
-            assert data == b'data'
+        if map_error == 0:
+            assert data == b"data"
         else:
-            assert data == b''
+            assert data == b""
 
 
 def test_TCPIPinstrVxi11_write():
     client = setup_TCPIPinstrVxi11_mock()
     for map_error in VXI11_ERRORS_TO_VISA.keys():
         # Need to return the length of the block written, just use length of block passed in
-        client.interface.device_write = MagicMock(side_effect=lambda a,b,c,d,block: (map_error, len(block)))
-        size, error = client.write(b'data')
+        client.interface.device_write = MagicMock(
+            side_effect=lambda a, b, c, d, block: (map_error, len(block))
+        )
+        size, error = client.write(b"data")
 
         assert error == VXI11_ERRORS_TO_VISA[map_error]
 
 
 # Test changes CoreClient read and write to throw a timeout
 # error when the timeout is exceeded vs generic io_error
+
 
 def setup_CoreClient_mock():
     CoreClient.__init__ = MagicMock(return_value=None)
@@ -62,28 +69,33 @@ def setup_CoreClient_mock():
 
 def test_CoreClient_device_read():
     # Short circuit connection so this works w/o a real device
-    client=setup_CoreClient_mock()
-    def raise_timeout(a,b,c,d):
+    client = setup_CoreClient_mock()
+
+    def raise_timeout(a, b, c, d):
         raise socket.timeout("testtimout")
+
     client.make_call = MagicMock(side_effect=raise_timeout)
     error, reason, data = client.device_read(0, 1024, 5000, 5000, 0, 0)
-    
+
     assert error == ErrorCodes.io_timeout
     assert reason == "testtimout"
     # TODO - Does make_call return bytes or string?
     # It looks like the higher level code forces to bytes,
     # but the read unpack already returns bytes. The error
     # return case returns a string.
-    assert data == ''
+    assert data == ""
+
 
 def test_CoreClient_device_write():
     # Short circuit connection so this works w/o a real device
     client = setup_CoreClient_mock()
-    def raise_timeout(a,b,c,d):
+
+    def raise_timeout(a, b, c, d):
         raise socket.timeout("testtimout")
+
     client.make_call = MagicMock(side_effect=raise_timeout)
-    
-    error, reason = client.device_write(0, 5000, 5000, 0, b'data')
-    
+
+    error, reason = client.device_write(0, 5000, 5000, 0, b"data")
+
     assert error == ErrorCodes.io_timeout
     assert reason == "testtimout"

--- a/pyvisa_py/testsuite/test_vxi11.py
+++ b/pyvisa_py/testsuite/test_vxi11.py
@@ -1,14 +1,12 @@
 import socket
-import pytest
 
-from pyvisa_py import common
-from unittest.mock import MagicMock, patch
+
+from unittest.mock import MagicMock
 from pyvisa_py.protocols import vxi11
-from pyvisa_py.protocols.rpc import Packer, RawTCPClient, TCPPortMapperClient, Unpacker
 from pyvisa_py.protocols.vxi11 import CoreClient, ErrorCodes
-from pyvisa_py.tcpip import TCPIPInstrVxi11, Vxi11CoreClient
+from pyvisa_py.tcpip import TCPIPInstrVxi11
 from pyvisa_py.tcpip import VXI11_ERRORS_TO_VISA
-from ..sessions import Session, UnknownAttribute, VISARMSession
+from ..sessions import VISARMSession
 
 # Test vxi11.py changes to error handling
 

--- a/pyvisa_py/testsuite/test_vxi11.py
+++ b/pyvisa_py/testsuite/test_vxi11.py
@@ -1,0 +1,89 @@
+import socket
+import pytest
+
+from pyvisa_py import common
+from unittest.mock import MagicMock, patch
+from pyvisa_py.protocols import vxi11
+from pyvisa_py.protocols.rpc import Packer, RawTCPClient, TCPPortMapperClient, Unpacker
+from pyvisa_py.protocols.vxi11 import CoreClient, ErrorCodes
+from pyvisa_py.tcpip import TCPIPInstrVxi11, Vxi11CoreClient
+from pyvisa_py.tcpip import VXI11_ERRORS_TO_VISA
+from ..sessions import Session, UnknownAttribute, VISARMSession
+
+# Test vxi11.py changes to error handling
+
+# Test enhanced error returns from TCPIPInstrVxi11.read, write to
+# map VXI11 errors to VISA errors
+
+def setup_TCPIPinstrVxi11_mock():
+    # Short circuit connection so this works w/o a real device
+    TCPIPInstrVxi11.__init__ = MagicMock(return_value=None)
+    client = TCPIPInstrVxi11(VISARMSession, "TCPIP::169.254.12.34::5678",None, 2000)
+    client.interface = MagicMock()
+    client.max_recv_size = 1024
+    client.attrs = {}
+    client._io_timeout = 5000
+    client.link = 0
+    client.lock_timeout = 5000
+    return client
+
+def test_TCPIPinstrVxi11_read():
+    client = setup_TCPIPinstrVxi11_mock()
+    for map_error in VXI11_ERRORS_TO_VISA.keys():
+        client.interface.device_read = MagicMock(side_effect=lambda a,b,c,d,e,f: (map_error, vxi11.RX_END, b'data'))
+        data, error = client.read(1024)
+        assert error == VXI11_ERRORS_TO_VISA[map_error]
+        if (map_error == 0):
+            assert data == b'data'
+        else:
+            assert data == b''
+
+
+def test_TCPIPinstrVxi11_write():
+    client = setup_TCPIPinstrVxi11_mock()
+    for map_error in VXI11_ERRORS_TO_VISA.keys():
+        # Need to return the length of the block written, just use length of block passed in
+        client.interface.device_write = MagicMock(side_effect=lambda a,b,c,d,block: (map_error, len(block)))
+        size, error = client.write(b'data')
+
+        assert error == VXI11_ERRORS_TO_VISA[map_error]
+
+
+# Test changes CoreClient read and write to throw a timeout
+# error when the timeout is exceeded vs generic io_error
+
+def setup_CoreClient_mock():
+    CoreClient.__init__ = MagicMock(return_value=None)
+    client = CoreClient("169.254.12.34:5678")
+    client.packer = MagicMock()
+    client.unpacker = MagicMock()
+    return client
+
+
+def test_CoreClient_device_read():
+    # Short circuit connection so this works w/o a real device
+    client=setup_CoreClient_mock()
+    def raise_timeout(a,b,c,d):
+        raise socket.timeout("testtimout")
+    client.make_call = MagicMock(side_effect=raise_timeout)
+    error, reason, data = client.device_read(0, 1024, 5000, 5000, 0, 0)
+    
+    assert error == ErrorCodes.io_timeout
+    assert reason == "testtimout"
+    # TODO - Does make_call return bytes or string?
+    # It looks like the higher level code forces to bytes,
+    # but the read unpack already returns bytes. The error
+    # return case returns a string.
+    assert data == ''
+
+def test_CoreClient_device_write():
+    # Short circuit connection so this works w/o a real device
+    client = setup_CoreClient_mock()
+    def raise_timeout(a,b,c,d):
+        raise socket.timeout("testtimout")
+    client.make_call = MagicMock(side_effect=raise_timeout)
+    
+    error, reason = client.device_write(0, 5000, 5000, 0, b'data')
+    
+    assert error == ErrorCodes.io_timeout
+    assert reason == "testtimout"


### PR DESCRIPTION
- Fix vxi11.CoreClient device_read and device_write calls to return io_timeout instead of io_error when a socket timeout execption is handled
- Change error 29 in tcpip.VXI11_ERRORS_TO_VISA to return StatusCode.error_system_error vs StatusCode.error_window_already_mapped as it seems better to return a general error vs something that doesn't really map at all. create_intr_chan also isn't implement at this point so we shouldn't get the error at all.
- Change tcpip.TCPIPInstrVxi11 read and write calls to use VXI11_ERRORS_TO_VISA mappings instead of always returning io_error
- Add test code to validate the operational changes of the functions modified.
